### PR TITLE
Minor piekit refactoring

### DIFF
--- a/pieapp/app/main.py
+++ b/pieapp/app/main.py
@@ -47,7 +47,7 @@ class PieAudioApp(MainWindow, ConfigAccessor):
 
     def preparePlugins(self) -> None:
         """ Prepare all (or selected) Plugins """
-        Managers(SysManagers.Plugins).mount(self)
+        Managers(SysManagers.Plugins).init(self)
         self.signalPluginsReady.emit()
 
     def notifyPluginReady(self):

--- a/pieapp/app/setup.py
+++ b/pieapp/app/setup.py
@@ -30,7 +30,7 @@ def setup_application() -> None:
 
     if not check_crabs():
         restore_crabs()
-        Managers.mount(*Config.MANAGERS)
+        Managers.init(*Config.MANAGERS)
 
         if splash:
             splash.close()
@@ -39,7 +39,7 @@ def setup_application() -> None:
         wizard.show()
         sys.exit(app.exec())
 
-    Managers.mount(*Config.MANAGERS)
+    Managers.init(*Config.MANAGERS)
 
     if splash:
         splash.close()

--- a/pieapp/app/start.py
+++ b/pieapp/app/start.py
@@ -11,7 +11,7 @@ def start_application():
     from pieapp.app.main import PieAudioApp
     qapp = getApplication()
 
-    theme = Managers.get(SysManagers.Assets).theme
+    theme = Managers.get(SysManagers.Assets).getTheme()
     if theme:
         if Config.ASSETS_USE_STYLE:
             qapp.setStyleSheet(getTheme(theme))

--- a/pieapp/containers/content-table/plugin/api/api.py
+++ b/pieapp/containers/content-table/plugin/api/api.py
@@ -8,7 +8,7 @@ from piekit.plugins.api.api import PiePluginAPI
 
 class ContentTableAPI(PiePluginAPI):
 
-    def mount(self) -> None:
+    def init(self) -> None:
         self.file_struct = ContentTableStruct()
         self.prepare_parent_table()
 

--- a/pieapp/containers/settings/plugin/plugin.py
+++ b/pieapp/containers/settings/plugin/plugin.py
@@ -88,7 +88,7 @@ class MainSettingsWidget(
         self.localeCBox.addItems(locales)
         self.localeCBox.setCurrentText(self.getConfig("locales.locale", Config.DEFAULT_LOCALE, section=Sections.User))
 
-        themes = Managers(SysManagers.Assets).themes
+        themes = Managers(SysManagers.Assets).getThemes()
         self.themeCBox = QtWidgets.QComboBox()
         self.themeCBox.addItems(themes)
         self.themeCBox.setCurrentText(self.getConfig("theme", section=Sections.User))

--- a/pieapp/wizard/wizard.py
+++ b/pieapp/wizard/wizard.py
@@ -20,7 +20,7 @@ class LocaleWizardPage(QtWidgets.QWizardPage):
 
         self._parent = parent
         self._locales = Config.LOCALES
-        self._curLocale = Managers(SysManagers.Configs)(
+        self._curLocale = Managers(SysManagers.Configs).get(
             Sections.User, "locales.locale", Config.DEFAULT_LOCALE
         )
         self._localesRev = {v: k for (k, v) in self._locales.items()}
@@ -32,7 +32,9 @@ class LocaleWizardPage(QtWidgets.QWizardPage):
         self.comboBox.addItems([self._locales.get(i) for (i, _) in self._locales.items()])
         self.comboBox.currentIndexChanged.connect(self.getResult)
 
-        self.localeLabel = QtWidgets.QLabel(Managers(SysManagers.Locales)(Sections.Shared, "Select locale"))
+        self.localeLabel = QtWidgets.QLabel(
+            Managers(SysManagers.Locales).get(Sections.Shared, "Select locale")
+        )
         self.localeLabel.setStyleSheet("QLabel{font-size: 25pt; padding-bottom: 20px;}")
 
         layout = QtWidgets.QVBoxLayout()
@@ -61,14 +63,16 @@ class ThemeWizardPage(QtWidgets.QWizardPage):
 
         self.comboBox = QtWidgets.QComboBox()
         self.comboBox.setStyleSheet("QComboBox{font-size: 12pt;}")
-        self.comboBox.addItems(Managers(SysManagers.Assets).themes)
+        self.comboBox.addItems(Managers(SysManagers.Assets).getTheme())
         self.comboBox.currentIndexChanged.connect(self.getResult)
 
-        self._curTheme = Managers(SysManagers.Configs)(
-            Sections.User, "assets.theme", default=Managers(SysManagers.Assets).theme
+        self._curTheme = Managers(SysManagers.Configs).get(
+            Sections.User, "assets.theme", default=Managers(SysManagers.Assets).getTheme()
         )
 
-        themeLabel = QtWidgets.QLabel(Managers(SysManagers.Locales)(Sections.Shared, "Select theme"))
+        themeLabel = QtWidgets.QLabel(
+            Managers(SysManagers.Locales).get(Sections.Shared, "Select theme")
+        )
         themeLabel.setStyleSheet("QLabel{font-size: 25pt; padding-bottom: 20px;}")
 
         layout = QtWidgets.QVBoxLayout()
@@ -110,7 +114,7 @@ class FfmpegWizardPage(QtWidgets.QWizardPage):
             }
         """)
         self.lineEditButton.setIcon(QIcon(
-            Managers(SysManagers.Assets)(Sections.Shared, "open-folder.png")
+            Managers(SysManagers.Assets).get(Sections.Shared, "open-folder.png")
         ))
         self.lineEditButton.clicked.connect(self.selectFfmpegPath)
 
@@ -131,7 +135,9 @@ class FfmpegWizardPage(QtWidgets.QWizardPage):
 
     @Slot()
     def selectFfmpegPath(self):
-        directory = QFileDialog(self, Managers(SysManagers.Locales)(Sections.Shared, "Select ffmpeg directory"))
+        directory = QFileDialog(self, Managers(SysManagers.Locales).get(
+            Sections.Shared, "Select ffmpeg directory"
+        ))
         directory.setFileMode(QFileDialog.FileMode.Directory)
         directory.setOption(QFileDialog.Option.ShowDirsOnly, False)
         directory.getExistingDirectory(dir=str(Config.USER_ROOT))

--- a/piekit/config/config.py
+++ b/piekit/config/config.py
@@ -59,34 +59,34 @@ TEMPLATE_FILES: Lock = [
 
 
 # Managers startup configuration
-# TODO: Replace `mount` attribute with Qt signal name (str) and emit it via `QMetaObject` -> `invokeMethod`
+# TODO: Replace `init` attribute with Qt signal name (str) and emit it via `QMetaObject` -> `invokeMethod`
 MANAGERS: Lock = [
     ManagerConfig(
         import_string="piekit.managers.configs.manager.ConfigManager",
-        mount=True
+        init=True
     ),
     ManagerConfig(
         import_string="piekit.managers.locales.manager.LocaleManager",
-        mount=True
+        init=True
     ),
     ManagerConfig(
         import_string="piekit.managers.assets.manager.AssetsManager",
-        mount=True
+        init=True
     ),
     ManagerConfig(
         import_string="piekit.managers.plugins.manager.PluginManager",
-        mount=False
+        init=False
     ),
     ManagerConfig(
         import_string="piekit.managers.menus.manager.MenuManager",
-        mount=True
+        init=True
     ),
     ManagerConfig(
         import_string="piekit.managers.toolbars.manager.ToolBarManager",
-        mount=True
+        init=True
     ),
     ManagerConfig(
         import_string="piekit.managers.toolbuttons.manager.ToolButtonManager",
-        mount=True
+        init=True
     )
 ]

--- a/piekit/mainwindow/main.py
+++ b/piekit/mainwindow/main.py
@@ -64,7 +64,7 @@ class MainWindow(
                 return False
 
         QApplication.processEvents()
-        Managers.unmount(full_house=True)
+        Managers.shutdown(full_house=True)
 
         return True
 

--- a/piekit/managers/actions/mixins.py
+++ b/piekit/managers/actions/mixins.py
@@ -9,12 +9,16 @@ from piekit.managers.structs import SysManagers, Sections
 
 class ActionAccessor:
 
-    def addAction(self, section: Union[str, Sections], parent: QObject, name: str = None) -> QAction:
+    def add_action(self, section: Union[str, Sections], parent: QObject, name: str = None) -> QAction:
         action = QAction(parent=parent)
         return Managers(SysManagers.Actions).addAction(section or Sections.Shared, name, action)
 
-    def getAction(self, section: str, name: str) -> QAction:
+    def get_action(self, section: str, name: str) -> QAction:
         return Managers(SysManagers.ToolBars).getToolBar(section, name)
 
-    def getActions(self, section: Union[str, Sections], *names: str) -> list[QAction]:
+    def get_actions(self, section: Union[str, Sections], *names: str) -> list[QAction]:
         return Managers(SysManagers.ToolBars).getToolBars(section, *names)
+
+    addAction = add_action
+    getAction = get_action
+    getActions = get_actions

--- a/piekit/managers/assets/manager.py
+++ b/piekit/managers/assets/manager.py
@@ -32,7 +32,7 @@ class AssetsManager(BaseManager):
         if not self._theme and theme_folders:
             self._theme = self._themes[0]
 
-    def mount(self) -> None:
+    def init(self) -> None:
         # Read app/user configuration
         self._read_root_assets(Config.APP_ROOT, Sections.Shared)
         self._read_root_assets(Config.USER_ROOT, Sections.User)
@@ -96,6 +96,12 @@ class AssetsManager(BaseManager):
     def get_icon(self, section: str, key: Any, default: Any = None) -> QIcon:
         return QIcon(self.get(section, key, default))
 
+    def get_theme(self) -> str:
+        return self._theme
+
+    def get_themes(self) -> list[str]:
+        return self._themes
+
     @property
     def root(self):
         return self._assets_folder
@@ -110,3 +116,5 @@ class AssetsManager(BaseManager):
 
     getSvg = get_svg
     getIcon = get_icon
+    getTheme = get_theme
+    getThemes = get_themes

--- a/piekit/managers/assets/mixins.py
+++ b/piekit/managers/assets/mixins.py
@@ -16,7 +16,7 @@ class AssetsAccessor:
         default: typing.Any = None,
         section: Union[str, Sections] = Sections.Shared
     ) -> typing.Any:
-        return Managers(SysManagers.Assets)(self.section or section, key, default)
+        return Managers(SysManagers.Assets).get(self.section or section, key, default)
 
     def get_asset_icon(
         self,

--- a/piekit/managers/base.py
+++ b/piekit/managers/base.py
@@ -14,15 +14,15 @@ class BaseManager:
         # Just a logger
         self._logger = logger
 
-        # Is manager mounted
-        self._mounted: bool = False
+        # Is manager ready
+        self._ready: bool = False
 
-    def mount(self, *args, **kwargs) -> None:
+    def init(self, *args, **kwargs) -> None:
         """
-        Main and optional entrypoint
+        Optional initializer
         """
 
-    def unmount(self, *args, **kwargs):
+    def shutdown(self, *args, **kwargs):
         """
         This method serves to reset all containers, variables etc.
         Don't use it to delete data from memory
@@ -32,6 +32,8 @@ class BaseManager:
         """
         This method reload manager
         """
+        self.shutdown()
+        self.init()
 
     def add(self, *args, **kwargs) -> None:
         pass
@@ -55,12 +57,12 @@ class BaseManager:
         """
 
     @property
-    def mounted(self) -> bool:
-        return self._mounted
+    def ready(self) -> bool:
+        return self._ready
 
-    @mounted.setter
-    def mounted(self, mounted: bool) -> None:
-        self._mounted = mounted
+    @ready.setter
+    def ready(self, ready: bool) -> None:
+        self._ready = ready
 
     def __call__(self, *args, **kwargs):
         return self.get(*args, **kwargs)

--- a/piekit/managers/configs/manager.py
+++ b/piekit/managers/configs/manager.py
@@ -24,7 +24,7 @@ class ConfigManager(BaseManager):
         self._configuration: Dotty[str, dict[str, typing.Any]] = Dotty({})
         self._observer = FileSystemObserver()
 
-    def mount(self) -> None:
+    def init(self) -> None:
         # Read app/user configuration
         self._read_root_configuration(Config.APP_ROOT / Config.USER_CONFIG_FOLDER, Sections.Shared)
         self._read_root_configuration(Config.USER_ROOT / Config.USER_CONFIG_FOLDER, Sections.User)
@@ -66,13 +66,9 @@ class ConfigManager(BaseManager):
 
             self._observer.add_handler(str(folder), str(folder.name))
 
-    def unmount(self, *args, **kwargs) -> None:
+    def shutdown(self, *args, **kwargs) -> None:
         self._configuration = Dotty({})
         self._observer.remove_handlers(full_house=True)
-
-    def reload(self) -> None:
-        self.unmount()
-        self.mount()
 
     @lru_cache
     def get(

--- a/piekit/managers/configs/mixins.py
+++ b/piekit/managers/configs/mixins.py
@@ -15,13 +15,13 @@ class ConfigAccessor:
         default: Any = None,
         section: Union[str, Sections] = Sections.Shared
     ) -> Any:
-        return Managers.get(SysManagers.Configs).get(self.section or section, key, default)
+        return Managers(SysManagers.Configs).get(self.name or section, key, default)
 
     def set_config(self, key: Any, data: Any) -> None:
-        Managers.get(SysManagers.Configs).set(self.section, key, data)
+        Managers(SysManagers.Configs).set(self.name, key, data)
 
     def delete_config(self, key: Any) -> None:
-        Managers.get(SysManagers.Configs).delete(self.section, key)
+        Managers(SysManagers.Configs).delete(self.name, key)
 
     getConfig = get_config
     setConfig = set_config

--- a/piekit/managers/configs/mixins.py
+++ b/piekit/managers/configs/mixins.py
@@ -15,7 +15,7 @@ class ConfigAccessor:
         default: Any = None,
         section: Union[str, Sections] = Sections.Shared
     ) -> Any:
-        return Managers(SysManagers.Configs).get(self.name or section, key, default)
+        return Managers(SysManagers.Configs).get(section or self.name, key, default)
 
     def set_config(self, key: Any, data: Any) -> None:
         Managers(SysManagers.Configs).set(self.name, key, data)

--- a/piekit/managers/exceptions.py
+++ b/piekit/managers/exceptions.py
@@ -12,10 +12,10 @@ class DependencyNotFoundError(AttributeError):
         return f"Required manager {self._name} not found"
 
 
-class ManagerNotMountedError(AttributeError):
+class ManagerNotReadyError(AttributeError):
 
     def __init__(self, name: str) -> None:
         self._name = name
 
     def __str__(self):
-        return f"Manager {self._name} not mounted"
+        return f"Manager {self._name} not ready"

--- a/piekit/managers/locales/manager.py
+++ b/piekit/managers/locales/manager.py
@@ -22,7 +22,7 @@ class LocaleManager(BaseManager):
         self._roots: set[Path] = set()
         self._translations: dict[str, dict[str, str]] = {}
 
-    def mount(self) -> None:
+    def init(self) -> None:
         # Read app/user configuration
         self._read_root_translations(Config.APP_ROOT, Sections.Shared)
         self._read_root_translations(Config.USER_ROOT, Sections.User)
@@ -51,12 +51,12 @@ class LocaleManager(BaseManager):
 
                 self._translations[file.stem].update(**read_json(str(file)))
 
-    def unmount(self, *args, **kwargs) -> None:
+    def shutdown(self, *args, **kwargs) -> None:
         self._translations = {}
 
     def reload(self) -> None:
-        self.unmount()
-        self.mount()
+        self.shutdown()
+        self.init()
 
     def get(self, section: str, key: str) -> str:
         if section not in self._translations:

--- a/piekit/managers/menus/mixins.py
+++ b/piekit/managers/menus/mixins.py
@@ -11,7 +11,7 @@ from piekit.managers.structs import SysManagers, Sections
 
 class MenuAccessor:
 
-    def addMenuBar(
+    def add_menu_bar(
         self,
         parent: QWidget = None,
         name: str = None
@@ -19,10 +19,10 @@ class MenuAccessor:
         menuBar = QMenuBar(parent)
         return Managers(SysManagers.Menus).addMenuBar(name or Sections.Shared, menuBar)
 
-    def getMenuBar(self, name: str) -> QMenuBar:
+    def get_menu_bar(self, name: str) -> QMenuBar:
         return Managers(SysManagers.Menus).getMenuBar(name or Sections.Shared)
 
-    def addMenu(
+    def add_menu(
         self,
         parent: QMenuBar = None,
         section: str = None,
@@ -37,7 +37,7 @@ class MenuAccessor:
 
         return Managers(SysManagers.Menus).addMenu(section or Sections.Shared, name, menu)
 
-    def addMenuItem(
+    def add_menu_item(
         self,
         section: str = None,
         menu: str = None,
@@ -53,8 +53,15 @@ class MenuAccessor:
         menuInstance.addMenuItem(name, text, triggered, icon, before, index)
         return manager.addMenuItem(section or Sections.Shared, menu, name, menuInstance)
 
-    def getMenu(self, section: str, name: str) -> PieMenu:
+    def get_menu(self, section: str, name: str) -> PieMenu:
         return Managers(SysManagers.Menus).getMenu(section or Sections.Shared, name)
 
-    def getMenuItem(self, section: str, menu: str, name: str) -> QAction:
+    def get_menu_item(self, section: str, menu: str, name: str) -> QAction:
         return Managers(SysManagers.Menus).getMenuItem(section, menu, name)
+
+    addMenu = add_menu
+    getMenu = get_menu
+    addMenuBar = add_menu_bar
+    getMenuBar = get_menu_bar
+    getMenuItem = get_menu_item
+    addMenuItem = add_menu_item

--- a/piekit/managers/plugins/decorators.py
+++ b/piekit/managers/plugins/decorators.py
@@ -35,9 +35,9 @@ def on_plugin_available(
     return func
 
 
-def on_plugin_unmount(func: Callable = None, target: Optional[str] = None):
+def on_plugin_shutdown(func: Callable = None, target: Optional[str] = None):
     """
-    Method decorator used to handle plugins unmount on Spyder.
+    Method decorator used to handle plugins shutdown on Spyder.
 
     This decorator will be called **before** the specified plugins is deleted
     and also **before** the plugins that uses the decorator is destroyed.
@@ -53,18 +53,18 @@ def on_plugin_unmount(func: Callable = None, target: Optional[str] = None):
         func(callable): The same method that was given as input.
     """
     if func is None:
-        return functools.partial(on_plugin_unmount, plugin=target)
+        return functools.partial(on_plugin_shutdown, plugin=target)
 
     if target is None:
         raise PieException(
-            "A method `on_plugin_unmount` must have a well "
+            "A method `on_plugin_shutdown` must have a well "
             "defined plugins keyword argument value. "
             "For example - target=Container.Workbench"
         )
 
-    func.plugin_unmount = target
+    func.plugin_shutdown = target
     return func
 
 
 onPluginAvailable = on_plugin_available
-onPluginUnmount = on_plugin_unmount
+onPluginShutdown = on_plugin_shutdown

--- a/piekit/managers/registry.py
+++ b/piekit/managers/registry.py
@@ -5,7 +5,7 @@ from piekit.managers.base import BaseManager
 from piekit.managers.structs import ManagerConfig
 from piekit.config import Config
 from piekit.utils.modules import import_by_string
-from piekit.managers.exceptions import ManagerNotMountedError, DependencyNotFoundError
+from piekit.managers.exceptions import ManagerNotReadyError, DependencyNotFoundError
 
 
 class ManagersRegistry:
@@ -14,7 +14,7 @@ class ManagersRegistry:
         # Just a logger
         self._logger = logger
 
-        # Set with stored `BaseManager` base classes. Use to reload them
+        # Dictionary with stored `BaseManager` base classes. Use to reload them
         self._managers_instances: dict[str, BaseManager] = {}
 
     def _check_dependencies(self, obj):
@@ -28,67 +28,69 @@ class ManagersRegistry:
             if dependency not in managers and not hasattr(self, dependency):
                 raise DependencyNotFoundError(dependency)
 
-            if dependency in managers and not self._is_mounted(dependency):
+            if dependency in managers and not self._is_ready(dependency):
                 # TODO: Add managers order resolver
-                raise ManagerNotMountedError(dependency)
+                raise ManagerNotReadyError(dependency)
 
-    def _mount_manually(self, manager: BaseManager, *args, **kwargs) -> None:
+    def _init_manually(self, manager: BaseManager, *args, **kwargs) -> None:
         """ 
-        Mount manager manualy. Pass manager class (not an instance) with args and kwargs
+        Initialize manager manualy. Pass manager class (not an instance) with args and kwargs
 
         For example:
         >>> from piekit.managers.registry import Managers
         >>> from piekit.managers.configs.manager import ConfigManager
-        >>> Managers.mount(ConfigManager, PathConfig(...), ...)
+        >>> Managers.init(ConfigManager, PathConfig(...), ...)
         """
         manager = manager()
         self._check_dependencies(manager)
-        self._logger.info(f"Mounting `{manager.__class__.__name__}`")
+        self._logger.info(f"Initializing `{manager.__class__.__name__}`")
 
-        manager.mount(*args, **kwargs)
+        manager.init(*args, **kwargs)
         self._managers_instances[manager.name] = manager
 
         setattr(self, manager.name, manager)
-        setattr(manager, "mounted", True)
+        setattr(manager, "ready", True)
 
-    def _mount_from_config(self, config: ManagerConfig) -> None:
-        """ Mount manager from dictionary """
+    def _init_from_config(self, config: ManagerConfig) -> None:
+        """
+        Initialize manager from `ManagerConfig` structure
+        """
         manager_instance = import_by_string(config.import_string)()
         self._check_dependencies(manager_instance)
 
-        self._logger.info(f"Mounting `{manager_instance.__class__.__name__}`")
-        if config.mount is True:
-            manager_instance.mount(*config.args, **config.kwargs)
+        self._logger.info(f"Initializing `{manager_instance.__class__.__name__}`")
+        if config.init is True:
+            manager_instance.init(*config.args, **config.kwargs)
 
         self._managers_instances[manager_instance.name] = manager_instance
         setattr(self, manager_instance.name, manager_instance)
-        setattr(manager_instance, "mounted", config.mount)
+        setattr(manager_instance, "ready", config.init)
 
-    def mount(self, *managers: Union[ManagerConfig, BaseManager]) -> None:
+    def init(self, *managers: Union[ManagerConfig, BaseManager]) -> None:
         """
-        Mount (add) managers by import string or instance of manager
-        >>> Managers.mount(*Config.MANAGERS)
+        Add and initialize managers via import string or via `BaseManager` instance
+        >>> Managers.init(*Config.MANAGERS)
         """
         for manager in managers:
             if isinstance(manager, ManagerConfig):
-                self._mount_from_config(manager)
+                self._init_from_config(manager)
 
             elif issubclass(manager, BaseManager):
-                self._mount_manually(manager)
+                self._init_manually(manager)
 
             else:
                 self._logger.info(f"Manager {manager} has incorrect `{type(manager)}` type. Skipping.")
                 continue
 
-    def unmount(self, *managers: str, full_house: bool = False) -> None:
-        self._logger.info("Preparing to unmount all managers")
+    def shutdown(self, *managers: str, full_house: bool = False) -> None:
+        self._logger.info("Preparing to shutdown all managers")
         managers = reversed(self._managers_instances.keys()) if full_house else managers
         managers_instances = [self._managers_instances.get(i) for i in managers or self._managers_instances.keys()]
 
         for manager_instance in managers_instances:
-            self._logger.info(f"Unmounting `{manager_instance.__class__.__name__}` from `{self.__class__.__name__}`")
+            self._logger.info(f"Shutting down `{manager_instance.__class__.__name__}` from `{self.__class__.__name__}`")
             manager_name = manager_instance.name
-            manager_instance.unmount(full_house=True)
+            manager_instance.shutdown(full_house=True)
             delattr(self, manager_name)
 
     def reload(self, *managers: tuple[BaseManager], full_house: bool = False):
@@ -106,15 +108,15 @@ class ManagersRegistry:
             self._logger.info(f"Destroying `{manager.__class__.__name__}`")
             delattr(self, manager)
 
-    def _is_mounted(self, name: str) -> bool:
+    def _is_ready(self, name: str) -> bool:
         manager = getattr(self, name)
-        return manager.mounted
+        return manager.ready
 
     def get(self, manager: str) -> BaseManager:
         try:
             return self.__getattribute__(manager)
         except AttributeError:
-            raise ManagerNotMountedError(manager)
+            raise ManagerNotReadyError(manager)
 
     def __call__(self, *args, **kwargs):
         return self.get(*args, **kwargs)

--- a/piekit/managers/shortcuts/manager.py
+++ b/piekit/managers/shortcuts/manager.py
@@ -14,5 +14,5 @@ class ShortcutsManager(BaseManager):
 
         self._shortcuts: dict[str, QShortcut] = {}
 
-    def mount(self, section: str, shortcut: str, parent: MainWindow = None) -> None:
+    def init(self, section: str, shortcut: str, parent: MainWindow = None) -> None:
         pass

--- a/piekit/managers/structs.py
+++ b/piekit/managers/structs.py
@@ -46,7 +46,7 @@ class Sections:
 @dt.dataclass(frozen=True, eq=False)
 class ManagerConfig:
     import_string: typing.Optional[str]
-    mount: bool = dt.field(default=False)
+    init: bool = dt.field(default=False)
     args: tuple = dt.field(default_factory=tuple)
     kwargs: dict = dt.field(default_factory=dict)
 

--- a/piekit/managers/toolbars/mixins.py
+++ b/piekit/managers/toolbars/mixins.py
@@ -11,11 +11,11 @@ from piekit.widgets.toolbars import PieToolBar
 
 class ToolBarAccessor:
 
-    def addToolBar(self, parent: QObject, name: str = None) -> QToolBar:
+    def add_toolbar(self, parent: QObject, name: str = None) -> QToolBar:
         toolbar = PieToolBar(parent=parent)
         return Managers(SysManagers.ToolBars).addToolBar(name or Sections.Shared, toolbar)
 
-    def addToolBarItem(
+    def add_toolbar_item(
         self,
         section: str = None,
         name: str = None,
@@ -28,14 +28,21 @@ class ToolBarAccessor:
         toolbar.addToolBarItem(name, item, after, before)
         return manager.addItem(section or Sections.Shared, name, item)
 
-    def getToolBarItem(self, section: str, name: str) -> QWidget:
+    def get_toolbar_item(self, section: str, name: str) -> QWidget:
         return Managers(SysManagers.ToolBars).getItem(section, name)
 
-    def getToolBarItems(self, section: str, *names: str) -> list[QObject]:
+    def get_toolbar_items(self, section: str, *names: str) -> list[QObject]:
         return Managers(SysManagers.ToolBars).getItems(section, *names)
 
-    def getToolBar(self, name: str) -> QToolBar:
+    def get_toolbar(self, name: str) -> QToolBar:
         return Managers(SysManagers.ToolBars).getToolBar(name)
 
-    def getToolBars(self, *names: str) -> list[QToolBar]:
+    def get_toolbars(self, *names: str) -> list[QToolBar]:
         return Managers(SysManagers.ToolBars).getToolBars(*names)
+
+    addToolBar = add_toolbar
+    getToolBar = get_toolbar
+    getToolBars = get_toolbars
+    addToolBarItem = add_toolbar_item
+    getToolBarItem = get_toolbar_item
+    getToolBarItems = get_toolbar_items

--- a/piekit/managers/toolbuttons/manager.py
+++ b/piekit/managers/toolbuttons/manager.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 from typing import Union
 
-from PySide6.QtCore import QObject, Qt
-from PySide6.QtGui import QIcon
 from PySide6.QtWidgets import QToolButton
 
 from piekit.managers.structs import Sections

--- a/piekit/managers/toolbuttons/mixins.py
+++ b/piekit/managers/toolbuttons/mixins.py
@@ -11,7 +11,7 @@ from piekit.config import Config
 
 class ToolButtonAccessor:
 
-    def addToolButton(
+    def add_tool_button(
         self,
         parent: QObject,
         section: Union[str, Sections],
@@ -44,8 +44,12 @@ class ToolButtonAccessor:
 
         return Managers(SysManagers.ToolButton).addToolButton(section or Sections.Shared, name, toolButton)
 
-    def getToolButtons(self, section: str, *names: str) -> list[QObject]:
+    def get_tool_buttons(self, section: str, *names: str) -> list[QObject]:
         return Managers(SysManagers.ToolButton).getToolButtons(section, *names)
 
-    def getToolButton(self, section: str, name: str) -> QToolButton:
+    def get_tool_button(self, section: str, name: str) -> QToolButton:
         return Managers(SysManagers.ToolButton).getToolButton(section or Sections.Shared, name)
+
+    addToolButton = add_tool_button
+    getToolButton = get_tool_button
+    getToolButtons = get_tool_buttons

--- a/piekit/observers/filesystem.py
+++ b/piekit/observers/filesystem.py
@@ -35,11 +35,11 @@ class FileSystemObserver:
         self._handlers: dict = {}
         self._observer: Observer = Observer()
 
-    def mount(self) -> None:
+    def init(self) -> None:
         """ Start observer """
         self._observer.start()
 
-    def unmount(self) -> None:
+    def shutdown(self) -> None:
         """ Unschedule and stop observer """
         self._watchers = {}
         self._observer.unschedule_all()

--- a/piekit/plugins/api/api.py
+++ b/piekit/plugins/api/api.py
@@ -1,4 +1,4 @@
-from typing import Any, Union
+from typing import Any
 
 from piekit.plugins.plugins import PiePlugin
 from piekit.plugins.api.exceptions import ApiMethodNotFoundError
@@ -6,17 +6,24 @@ from piekit.plugins.api.exceptions import ApiMethodNotFoundError
 
 class PiePluginAPI:
 
-    def __init__(self, parent: Union[None, PiePlugin] = None) -> None:
+    def __init__(self, parent: PiePlugin) -> None:
         self._parent = parent
 
-    def mount(self) -> None:
+    def init(self) -> None:
         pass
 
-    def __call__(self, method: str, **kwargs) -> Any:
+    def shutdown(self, *args, **kwargs) -> None:
+        pass
+
+    def reload(self, *args, **kwargs) -> None:
+        self.init()
+        self.shutdown()
+
+    def call(self, method: str, **kwargs) -> Any:
         try:
             return self.__getattribute__(method)(**kwargs)
         except AttributeError:
-            raise ApiMethodNotFoundError(method)
+            raise AttributeError(method)
 
     @property
     def parent(self) -> PiePlugin:

--- a/piekit/plugins/api/exceptions.py
+++ b/piekit/plugins/api/exceptions.py
@@ -3,15 +3,6 @@ API exceptions
 """
 
 
-class NoApiImplementationError(AttributeError):
-
-    def __init__(self, plugin: str) -> None:
-        self._method = plugin
-
-    def __str__(self) -> str:
-        return f"Method {self._method} not found"
-
-
 class ApiMethodNotFoundError(AttributeError):
 
     def __init__(self, method: str) -> None:

--- a/piekit/plugins/api/helpers.py
+++ b/piekit/plugins/api/helpers.py
@@ -4,16 +4,15 @@ API helpers
 from typing import Any
 
 from piekit.plugins.api.api import PiePluginAPI
-from piekit.plugins.api.exceptions import NoApiImplementationError
 from piekit.plugins.helpers import get_plugin
 
 
 def get_api(plugin: str, method: str, **kwargs) -> Any:
     plugin_instance = get_plugin(plugin)
     if not isinstance(plugin_instance.api, PiePluginAPI):
-        raise NoApiImplementationError(plugin)
+        raise NotImplementedError(f"API {method} not found")
 
-    return plugin_instance.api(method, **kwargs)
+    return plugin_instance.api.call(method, **kwargs)
 
 
 getAPI = get_api

--- a/piekit/plugins/helpers.py
+++ b/piekit/plugins/helpers.py
@@ -7,7 +7,7 @@ from piekit.plugins.plugins import PiePlugin
 
 
 def get_plugin(plugin: str) -> PiePlugin:
-    return Managers(SysManagers.Plugins)(plugin)
+    return Managers(SysManagers.Plugins).get(plugin)
 
 
 getPlugin = get_plugin

--- a/piekit/plugins/observer.py
+++ b/piekit/plugins/observer.py
@@ -9,7 +9,7 @@ class PluginsObserverMixin:
 
     def __init__(self) -> None:
         self._plugin_availability_listeners = {}
-        self._plugin_unmount_listeners = {}
+        self._plugin_shutdown_listeners = {}
 
         for method_name in dir(self):
             method = getattr(self, method_name, None)
@@ -25,17 +25,17 @@ class PluginsObserverMixin:
 
                 self._plugin_availability_listeners[plugin_listen] = method_name
 
-            if hasattr(method, "plugin_unmount"):
-                object_unmount = method.plugin_unmount
+            if hasattr(method, "plugin_shutdown"):
+                object_shutdown = method.plugin_shutdown
 
-                if object_unmount not in self.requires + self.optional:
+                if object_shutdown not in self.requires + self.optional:
                     raise PieException(
                         f"Method {method_name} of {self} is trying to watch "
-                        f"plugin {object_unmount}, but that plugin is not "
+                        f"plugin {object_shutdown}, but that plugin is not "
                         f"listed in `requires` nor `optional`."
                     )
 
-                self._plugin_unmount_listeners[object_unmount] = method_name
+                self._plugin_shutdown_listeners[object_shutdown] = method_name
 
     def on_plugin_available(self, target: str) -> None:
         if target in self._plugin_availability_listeners:
@@ -49,11 +49,11 @@ class PluginsObserverMixin:
             method = getattr(self, method_name)
             method(target)
 
-    def on_plugin_unmount(self, target: str) -> None:
-        if target in self._plugin_unmount_listeners:
-            method_name = self._plugin_unmount_listeners[target]
+    def on_plugin_shutdown(self, target: str) -> None:
+        if target in self._plugin_shutdown_listeners:
+            method_name = self._plugin_shutdown_listeners[target]
             method = getattr(self, method_name)
             method()
 
     onPluginAvailable = on_plugin_available
-    onPluginUnmount = on_plugin_unmount
+    onPluginShutdown = on_plugin_shutdown

--- a/piekit/plugins/plugins.py
+++ b/piekit/plugins/plugins.py
@@ -112,7 +112,7 @@ class PiePlugin(
 
         if self.api and issubclass(self.api, PiePluginAPI):
             self.api = self.api(self)
-            self.api.mount()
+            self.api.init()
 
     def prepareBaseSignals(self):
         self.logger.info(f"Preparing base signals for {self.__class__.__name__}")
@@ -161,7 +161,7 @@ class PiePlugin(
         messageBox.setIcon(QMessageBox.Icon.Critical)
         messageBox.setText(error.title)
         messageBox.setInformativeText(error.description)
-        messageBox.setWindowTitle(Managers(SysManagers.Locales)("Error", section="shared"))
+        messageBox.setWindowTitle(Managers(SysManagers.Locales).get("Error", section="shared"))
         messageBox.exec()
 
     # Properties

--- a/piekit/utils/core.py
+++ b/piekit/utils/core.py
@@ -20,7 +20,7 @@ def get_application(*args, **kwargs):
 
 
 def restart_application() -> None:
-    Managers.unmount(full_house=True)
+    Managers.shutdown(full_house=True)
     QtCore.QCoreApplication.quit()
     QtCore.QProcess.startDetached(sys.executable, sys.argv)
 


### PR DESCRIPTION
* Methods `mount` and `unmount` has been renamed to `init` and `shutdown`
* Property `mounted` has been renamed to `ready`
* Method `reload` now have a default implementation with `shutdown` and `init` method call
* Properties `theme` and `themes` in `AssetsManager` has been renamed to `get_theme` and `get_themes`
* Attribute `mount` in `ManagerConfig` has been renamed to `init`
* Has been removed unclear managers `get` method call - now you need to use `get` method directly without using dunder method `__call__`. Example: Managers(SysManagers.Assets)(...)
* Exception `NoApiImplementationError` has been removed
* Small fixes